### PR TITLE
#32: add support for likes, education history and work history scopes (closes #32)

### DIFF
--- a/demo/index.ejs
+++ b/demo/index.ejs
@@ -62,7 +62,7 @@
             google: '795655891034-5tou4pabjpdjdcmunv1970ujkuqggj7m.apps.googleusercontent.com',
             linkedin: '778rorytckysk3'
           },
-          scopes: ['likes']
+          scopes: ['likes', 'education_history', 'work_history']
         },
         contacthub: window.ch,
         autofillOptions: {

--- a/demo/index.ejs
+++ b/demo/index.ejs
@@ -56,10 +56,13 @@
     <!-- start: Initialize ContacthubConnectSocial -->
     <script type="text/javascript">
       var contacthubConnectSocial = new window.ContacthubConnectSocial({
-        clientIds: {
-          facebook: '1882104035447885',
-          google: '795655891034-5tou4pabjpdjdcmunv1970ujkuqggj7m.apps.googleusercontent.com',
-          linkedin: '778rorytckysk3'
+        socialNetworks: {
+          clientIds: {
+            facebook: '1882104035447885',
+            google: '795655891034-5tou4pabjpdjdcmunv1970ujkuqggj7m.apps.googleusercontent.com',
+            linkedin: '778rorytckysk3'
+          },
+          scopes: ['likes']
         },
         contacthub: window.ch,
         autofillOptions: {

--- a/src/ContacthubConnectSocial.ts
+++ b/src/ContacthubConnectSocial.ts
@@ -17,7 +17,7 @@ export default class ContacthubConnectSocial {
     // fully validate "options" with tcomb
     Options(options as any);
 
-    this.socialNetworks = new SocialNetworks(options.clientIds);
+    this.socialNetworks = new SocialNetworks(options.socialNetworks);
     this.contacthub = options.contacthub;
     this.formFiller = new FormFiller(options.autofillOptions.fields);
 

--- a/src/models/contacthub-sdk-browser.ts
+++ b/src/models/contacthub-sdk-browser.ts
@@ -34,44 +34,84 @@ export type EventOptions = {
   properties?: Object
 };
 
-export type CustomerId = {
-  customerId: string
+export type Tags = {
+  auto: string[],
+  manual: string[]
 };
 
-export type CustomerTags = {
-  auto?: Array<string>,
-  manual?: Array<string>
+export type OtherContact = {
+  name?: string,
+  type?: 'MOBILE' | 'PHONE' | 'EMAIL' | 'FAX' | 'OTHER',
+  value?: string
 };
 
-export type CustomerContacts = {
+export type MobileDeviceType = 'IOS' | 'ANDROID' | 'WINDOWS_PHONE' | 'FIREOS';
+export type MobileDeviceNotificationCenter = 'APN' | 'GCM' | 'WNS' | 'ADM' | 'SNS';
+
+export type MobileDevice = {
+  appId: string,
+  identifier?: string,
+  name?: string,
+  type?: MobileDeviceType,
+  notificationService: MobileDeviceNotificationCenter
+};
+
+export type Contacts = {
   email?: string,
   fax?: string,
   mobilePhone?: string,
   phone?: string,
-  otherContacts?: string,
-  mobileDevices?: string
+  otherContacts?: OtherContact[],
+  mobileDevices?: MobileDevice[]
 };
 
-export type CustomerGeo = {
-  lat: string,
-  lon: string
+export type Geo = {
+  lat: number,
+  lon: number
 };
 
-export type CustomerAddress = {
+export type Address = {
   street?: string,
   city?: string,
   country?: string,
   province?: string,
   zip?: string,
-  geo?: CustomerGeo
+  geo?: Geo
 };
 
-export type CustomerCredential = {
+export type Credential = {
   username?: string,
   password?: string
 };
 
-export type CustomerSocial = {
+export type Education = {
+  id: string,
+  schoolType?: 'PRIMARY_SCHOOL' | 'SECONDARY_SCHOOL' | 'HIGH_SCHOOL' | 'COLLEGE' | 'OTHER',
+  schoolName?: string,
+  schoolConcentration?: string,
+  startYear?: number,
+  endYear?: number,
+  isCurrent?: boolean
+};
+
+export type Job = {
+  id: string,
+  companyIndustry?: string,
+  companyName?: string,
+  jobTitle?: string,
+  startDate?: string,
+  endDate?: string,
+  isCurrent?: boolean
+};
+
+export type Like = {
+  id: string,
+  category?: string,
+  name?: string,
+  createdTime?: string
+};
+
+export type Social = {
   facebook?: string,
   google?: string,
   instagram?: string,
@@ -80,7 +120,26 @@ export type CustomerSocial = {
   twitter?: string
 };
 
-export type CustomerBase = {
+export type Preference = {
+  key: string,
+  value: string
+};
+
+export type Subscription = {
+  id: string,
+  name?: string,
+  type?: string,
+  kind?: 'DIGITAL_MESSAGE' | 'SERVICE' | 'OTHER',
+  subscribed?: boolean,
+  startDate?: string,
+  endDate?: string,
+  subscriberId?: string,
+  registeredAt?: string,
+  updatedAt?: string,
+  preferences?: Preference[]
+};
+
+export type BaseProperties = {
   pictureUrl?: string,
   title?: string,
   prefix?: string,
@@ -91,25 +150,29 @@ export type CustomerBase = {
   dob?: string,
   locale?: string,
   timezone?: string,
-  contacts?: CustomerContacts,
-  address?: CustomerAddress,
-  credential?: CustomerCredential,
-  educations?: string,
-  likes?: Number,
-  socialProfile?: CustomerSocial,
-  jobs?: string,
-  subscriptions?: string
+  contacts?: Contacts,
+  address?: Address,
+  credential?: Credential,
+  educations?: Education[],
+  likes?: Like[],
+  socialProfile?: Social,
+  jobs?: Job[],
+  subscriptions?: Subscription[]
 };
 
 export type CustomerData = {
-  id?: string,
-  base?: CustomerBase,
+  externalId?: string,
+  base?: BaseProperties,
   extended?: Object,
   extra?: string,
-  tags?: CustomerTags,
-  externalId?: string
+  tags?: Tags
 };
 
+export type Customer = CustomerData & {
+  id: string,
+  registeredAt: string,
+  updatedAt: string
+};
 
 export type CHConfig = (method: 'config', options: ConfigOptions) => void;
 export type CHCustomer = (method: 'customer', options: CustomerData) => void;

--- a/src/models/facebook-api.ts
+++ b/src/models/facebook-api.ts
@@ -195,8 +195,7 @@ declare module FbGraphApi {
     min: number;
   }
 
-  export interface FbPage {
-    id: string;
+  export type FbPage = { id: string } & Partial<{
     about: string;
     access_token: string;
     ad_campaign: FbAdCampaign;
@@ -317,7 +316,7 @@ declare module FbGraphApi {
     website: string;
     were_here_count: number;
     written_by: string;
-  }
+  }>
 
   export interface FbVoipInfo {
     has_mobile_app: boolean;

--- a/src/models/facebook-api.ts
+++ b/src/models/facebook-api.ts
@@ -89,15 +89,15 @@ declare module FbGraphApi {
 
   export interface FbWorkExperience {
     id: string;
-    description: string;
-    employer: FbPage;
-    end_date: string;
-    from: FbUser;
-    location: FbPage;
-    position: FbPage;
-    projects: FbProjectExperience[];
-    start_date: string;
-    with: FbUser[];
+    description?: string;
+    employer?: FbPage;
+    end_date?: string;
+    from?: FbUser;
+    location?: FbPage;
+    position?: FbPage;
+    projects?: FbProjectExperience[];
+    start_date?: string;
+    with?: FbUser[];
   }
 
   export interface FbProjectExperience {
@@ -158,13 +158,13 @@ declare module FbGraphApi {
 
   export interface FbEducationExperience {
     id: string;
-    classes: FbExperience[];
-    concentration: FbPage[];
-    degree: FbPage;
-    school: FbPage;
-    type: string;
-    with: FbUser[];
-    year: FbPage;
+    classes?: FbExperience[];
+    concentration?: FbPage[];
+    degree?: FbPage;
+    school?: FbPage;
+    type?: string;
+    with?: FbUser[];
+    year?: FbPage;
   }
 
   export interface FbUserDevice {

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -173,6 +173,17 @@ export interface GoogleUser extends HelloUser {
   cherry-picked the keys we use from docs here: https://developer.linkedin.com/docs/fields/basic-profile
   note: linkedin sdk (apparently) converts each key to camelCase
 */
+
+export type MultiLocaleString = {
+  preferredLocale?: {
+    country: string,
+    language: string
+  },
+  localized: {
+    [k: string]: string
+  }
+}
+
 export type LinkedInUser = {
   id: string,
   firstName: string,
@@ -185,5 +196,32 @@ export type LinkedInUser = {
     day: number,
     month: number,
     year: number
-  }
+  },
+  educations?: {
+    id: string,
+    activities?: never,
+    degreeName?: never,
+    endMonthYear?: { year: number },
+    startMonthYear?: { year: number },
+    fieldsOfStudy?: never,
+    grade?: never,
+    notes?: never,
+    program?: never,
+    richMediaAssociations?: never,
+    school?: never,
+    schoolName?: MultiLocaleString
+  }[],
+  positions?: {
+    id: string,
+    company?: never,
+    companyName?: MultiLocaleString,
+    description?: never,
+    endMonthYear?: { year: number },
+    startMonthYear?: { year: number },
+    location?: never,
+    locationName?: never,
+    richMediaAssociations?: never,
+    title?: MultiLocaleString
+  }[]
+
 }

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -27,18 +27,26 @@ export type AutofillOptions = {
   fields: Fields
 }
 
+export type Scope = 'likes' | 'education_history' | 'work_history'
+
 export type Options = {
-  clientIds: SocialNetworksClientIds,
+  socialNetworks: {
+    clientIds: SocialNetworksClientIds,
+    scopes: Scope[]
+  },
   contacthub: ContactHubSDKBrowser,
   autofillOptions: AutofillOptions
 }
 
 // tcomb version of Options to validate at run-time
 export const Options = t.interface({
-  clientIds: t.interface({
-    facebook: t.maybe(t.String),
-    google: t.maybe(t.String),
-    linkedin: t.maybe(t.String)
+  socialNetworks: t.interface({
+    clientIds: t.interface({
+      facebook: t.maybe(t.String),
+      google: t.maybe(t.String),
+      linkedin: t.maybe(t.String)
+    }, { strict: true }),
+    scopes: t.maybe(t.list(t.enums.of(['likes', 'education_history', 'work_history'])))
   }, { strict: true }),
   contacthub: t.Function,
   autofillOptions: t.interface({

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -63,6 +63,8 @@ export const Options = t.interface({
   }, { strict: true })
 }, { strict: true, name: '"ContacthubConnectSocial"' });
 
+export type FacebookScope = 'email' | 'user_birthday' | 'user_likes' | 'user_education_history' | 'user_work_history'
+
 export type User = {
   base: CustomerBase & {
     contacts: CustomerContacts,

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -1,6 +1,6 @@
 import * as t from 'tcomb';
 import FbGraphApi from './facebook-api';
-import { CustomerBase, CustomerSocial, CustomerContacts, ContactHubSDKBrowser } from './contacthub-sdk-browser';
+import { BaseProperties as CustomerBase, Social as CustomerSocial, Contacts as CustomerContacts, ContactHubSDKBrowser } from './contacthub-sdk-browser';
 
 export type SocialNetworksClientIds = {
   facebook?: string,

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -180,5 +180,10 @@ export type LinkedInUser = {
   formattedName: string,
   pictureUrl: string,
   publicProfileUrl: string,
-  emailAddress: string
+  emailAddress: string,
+  birthDate?: {
+    day: number,
+    month: number,
+    year: number
+  }
 }

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -88,7 +88,7 @@ export type FacebookLike = {
   created_time: string,
   id: string,
   name: string,
-  pictures: any[]
+  pictures?: any[]
 }
 
 // copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/gapi.plus/index.d.ts

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -131,15 +131,15 @@ export interface GoogleUser extends HelloUser {
     url: string;
   };
   organizations: {
-    name: string;
-    department: string;
-    title: string;
+    name?: string;
+    department?: string;
+    title?: string;
     type: 'school' | 'work';
-    startDate: string;
-    endDate: string;
-    location: string;
-    description: string;
-    primary: boolean;
+    startDate?: string;
+    endDate?: string;
+    location?: string;
+    description?: string;
+    primary?: boolean;
   }[];
   placesLived: {
     value: string;
@@ -192,8 +192,8 @@ export type LinkedInUser = {
       id: number,
       activities?: never,
       degreeName?: never,
-      endMonthYear?: { year: number },
-      startMonthYear?: { year: number },
+      endDate?: { year: number, month: number },
+      startDate?: { year: number, month: number },
       fieldsOfStudy?: never,
       grade?: never,
       notes?: never,
@@ -210,13 +210,14 @@ export type LinkedInUser = {
     values: {
       id: number,
       company?: {
+        id: number,
         name: string,
         industry: string
       },
       companyName?: never,
       description?: never,
-      endMonthYear?: { year: number },
-      startMonthYear?: { year: number },
+      endDate?: { year: number, month: number },
+      startDate?: { year: number, month: number },
       location?: never,
       locationName?: never,
       richMediaAssociations?: never,

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -92,6 +92,7 @@ export type FacebookLike = {
 }
 
 // copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/gapi.plus/index.d.ts
+// see https://developers.google.com/+/web/api/rest/latest/people for official docs from Google
 export interface GoogleUser extends HelloUser {
   kind: 'plus#person';
   etag: string;
@@ -133,7 +134,7 @@ export interface GoogleUser extends HelloUser {
     name: string;
     department: string;
     title: string;
-    type: string;
+    type: 'school' | 'work';
     startDate: string;
     endDate: string;
     location: string;

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -174,16 +174,6 @@ export interface GoogleUser extends HelloUser {
   note: linkedin sdk (apparently) converts each key to camelCase
 */
 
-export type MultiLocaleString = {
-  preferredLocale?: {
-    country: string,
-    language: string
-  },
-  localized: {
-    [k: string]: string
-  }
-}
-
 export type LinkedInUser = {
   id: string,
   firstName: string,
@@ -198,30 +188,41 @@ export type LinkedInUser = {
     year: number
   },
   educations?: {
-    id: string,
-    activities?: never,
-    degreeName?: never,
-    endMonthYear?: { year: number },
-    startMonthYear?: { year: number },
-    fieldsOfStudy?: never,
-    grade?: never,
-    notes?: never,
-    program?: never,
-    richMediaAssociations?: never,
-    school?: never,
-    schoolName?: MultiLocaleString
-  }[],
+    values: {
+      id: number,
+      activities?: never,
+      degreeName?: never,
+      endMonthYear?: { year: number },
+      startMonthYear?: { year: number },
+      fieldsOfStudy?: never,
+      grade?: never,
+      notes?: never,
+      program?: never,
+      richMediaAssociations?: never,
+      school?: {
+        name: string
+      },
+      schoolName?: never,
+      isCurrent?: boolean
+    }[]
+  },
   positions?: {
-    id: string,
-    company?: never,
-    companyName?: MultiLocaleString,
-    description?: never,
-    endMonthYear?: { year: number },
-    startMonthYear?: { year: number },
-    location?: never,
-    locationName?: never,
-    richMediaAssociations?: never,
-    title?: MultiLocaleString
-  }[]
+    values: {
+      id: number,
+      company?: {
+        name: string,
+        industry: string
+      },
+      companyName?: never,
+      description?: never,
+      endMonthYear?: { year: number },
+      startMonthYear?: { year: number },
+      location?: never,
+      locationName?: never,
+      richMediaAssociations?: never,
+      title?: string,
+      isCurrent?: boolean
+    }[]
+  }
 
 }

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -32,7 +32,7 @@ export type Scope = 'likes' | 'education_history' | 'work_history'
 export type Options = {
   socialNetworks: {
     clientIds: SocialNetworksClientIds,
-    scopes: Scope[]
+    scopes?: Scope[]
   },
   contacthub: ContactHubSDKBrowser,
   autofillOptions: AutofillOptions

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -64,6 +64,7 @@ export const Options = t.interface({
 }, { strict: true, name: '"ContacthubConnectSocial"' });
 
 export type FacebookScope = 'email' | 'user_birthday' | 'user_likes' | 'user_education_history' | 'user_work_history'
+export type GoogleScope = 'email' | 'birthday'
 
 export type User = {
   base: CustomerBase & {

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -81,8 +81,14 @@ export interface HelloUser {
   email: string
 }
 
-export type FacebookFields = 'id' | 'first_name' | 'last_name' | 'gender' | 'birthday' | 'link' | 'email';
+export type FacebookFields = 'id' | 'first_name' | 'last_name' | 'gender' | 'birthday' | 'link' | 'email' | 'education' | 'work';
 export type FacebookUser = Pick<FbGraphApi.FbUser, FacebookFields> & HelloUser
+export type FacebookLike = {
+  created_time: string,
+  id: string,
+  name: string,
+  pictures: any[]
+}
 
 // copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/gapi.plus/index.d.ts
 export interface GoogleUser extends HelloUser {

--- a/src/socialNetworks/index.ts
+++ b/src/socialNetworks/index.ts
@@ -70,7 +70,7 @@ export default class SocialNetworks {
       Google.login({ scope: scopes.join(',') }).then(() => {
         Google.api('me').then((googleUser: GoogleUser) => {
           try {
-            const user = getUserFromGoogleUser(googleUser);
+            const user = getUserFromGoogleUser(googleUser, this.scopes);
             resolve(user);
           } catch (e) {
             reject(e);

--- a/src/socialNetworks/index.ts
+++ b/src/socialNetworks/index.ts
@@ -96,7 +96,7 @@ export default class SocialNetworks {
       const onLogin = () => {
         LinkedIn.API
           .Raw()
-          .url('/people/~:(picture-url,first-name,last-name,id,formatted-name,email-address,public-profile-url,educations,positions,birthDate)')
+          .url('/people/~:(picture-url,first-name,last-name,id,formatted-name,email-address,public-profile-url,educations,positions,date-of-birth)')
           .method('GET')
           .body()
           .result((linkedInUser: LinkedInUser) => {

--- a/src/socialNetworks/index.ts
+++ b/src/socialNetworks/index.ts
@@ -96,7 +96,7 @@ export default class SocialNetworks {
       const onLogin = () => {
         LinkedIn.API
           .Raw()
-          .url('/people/~:(picture-url,first-name,last-name,id,formatted-name,email-address,public-profile-url)')
+          .url('/people/~:(picture-url,first-name,last-name,id,formatted-name,email-address,public-profile-url,educations,positions,birthDate)')
           .method('GET')
           .body()
           .result((linkedInUser: LinkedInUser) => {

--- a/src/socialNetworks/index.ts
+++ b/src/socialNetworks/index.ts
@@ -87,6 +87,11 @@ export default class SocialNetworks {
 
     const LinkedIn = (window as any).IN;
 
+    /* LinkedIn scopes are different:
+      - they are set only in the app setting
+      - LinkedIn has no additional scopes apart from "profile" and "email" (which are both required by ContacthubSocialConnect)
+    */
+
     return new Promise((resolve) => {
       const onLogin = () => {
         LinkedIn.API

--- a/src/socialNetworks/index.ts
+++ b/src/socialNetworks/index.ts
@@ -1,7 +1,7 @@
 import { Promise } from 'es6-promise';
 import hello from '../vendor/hello';
 import injectLinkedInSDK from '../vendor/injectLinkedInSDK';
-import { Options, FacebookLike, Scope, FacebookScope, SocialNetworksClientIds, FacebookFields, FacebookUser, GoogleUser, LinkedInUser, User } from '../models';
+import { Options, FacebookLike, Scope, FacebookScope, GoogleScope, SocialNetworksClientIds, FacebookFields, FacebookUser, GoogleUser, LinkedInUser, User } from '../models';
 import { getUserFromFacebookUser, getUserFromGoogleUser, getUserFromLinkedInUser } from '../userConverters';
 
 export default class SocialNetworks {
@@ -22,7 +22,7 @@ export default class SocialNetworks {
     this.scopes = scopes;
   }
 
-  convertScopes(scopes: Scope[]): FacebookScope[] {
+  getFacebookScopesFromScopes(scopes: Scope[]): FacebookScope[] {
     const convertionMap: { [k in Scope]: FacebookScope } = {
       likes: 'user_likes',
       education_history: 'user_education_history',
@@ -40,7 +40,7 @@ export default class SocialNetworks {
     const Facebook = hello('facebook');
 
     const fields: FacebookFields[] = ['first_name', 'last_name', 'gender', 'birthday', 'link', 'email', 'education', 'work'];
-    const scopes: FacebookScope[] = ['email', 'user_birthday', ...this.convertScopes(this.scopes)];
+    const scopes: FacebookScope[] = ['email', 'user_birthday', ...this.getFacebookScopesFromScopes(this.scopes)];
 
     return new Promise((resolve, reject) => {
       Facebook.login({ scope: scopes.join(',') }).then(() => {
@@ -64,8 +64,10 @@ export default class SocialNetworks {
 
     const Google = hello('google');
 
+    const scopes: GoogleScope[] = ['email', 'birthday'];
+
     return new Promise((resolve, reject) => {
-      Google.login({ scope: 'email' }).then(() => {
+      Google.login({ scope: scopes.join(',') }).then(() => {
         Google.api('me').then((googleUser: GoogleUser) => {
           try {
             const user = getUserFromGoogleUser(googleUser);

--- a/src/socialNetworks/index.ts
+++ b/src/socialNetworks/index.ts
@@ -47,7 +47,7 @@ export default class SocialNetworks {
         Promise.all([Facebook.api('me', { fields }), Facebook.api('me/likes')])
           .then(([facebookUser, likes]: [FacebookUser, FacebookLike[]]) => {
             try {
-              const user = getUserFromFacebookUser(facebookUser);
+              const user = getUserFromFacebookUser(facebookUser, this.scopes);
               resolve(user);
             } catch (e) {
               reject(e);
@@ -100,7 +100,7 @@ export default class SocialNetworks {
           .method('GET')
           .body()
           .result((linkedInUser: LinkedInUser) => {
-            resolve(getUserFromLinkedInUser(linkedInUser));
+            resolve(getUserFromLinkedInUser(linkedInUser, this.scopes));
           });
       }
 

--- a/src/socialNetworks/index.ts
+++ b/src/socialNetworks/index.ts
@@ -1,19 +1,25 @@
 import { Promise } from 'es6-promise';
 import hello from '../vendor/hello';
 import injectLinkedInSDK from '../vendor/injectLinkedInSDK';
-import { SocialNetworksClientIds, FacebookFields, FacebookUser, GoogleUser, LinkedInUser, User } from '../models';
+import { Options, Scope, FacebookScope, SocialNetworksClientIds, FacebookFields, FacebookUser, GoogleUser, LinkedInUser, User } from '../models';
 import { getUserFromFacebookUser, getUserFromGoogleUser, getUserFromLinkedInUser } from '../userConverters';
 
 export default class SocialNetworks {
 
   clientIds: SocialNetworksClientIds
+  scopes: Scope[]
 
-  constructor(clientIds: SocialNetworksClientIds) {
+  constructor(socialNetworksOptions: Options['socialNetworks']) {
+    const { clientIds, scopes } = socialNetworksOptions;
+
     if (clientIds.linkedin) {
       injectLinkedInSDK(clientIds.linkedin);
     }
+
     hello.init({ ...clientIds as { [k: string]: string } }); // "..." are needed because `hello` modifies the given options
+
     this.clientIds = clientIds;
+    this.scopes = scopes;
   }
 
   loginWithFacebook(): Promise<User> {

--- a/src/socialNetworks/index.ts
+++ b/src/socialNetworks/index.ts
@@ -19,7 +19,7 @@ export default class SocialNetworks {
     hello.init({ ...clientIds as { [k: string]: string } }); // "..." are needed because `hello` modifies the given options
 
     this.clientIds = clientIds;
-    this.scopes = scopes;
+    this.scopes = scopes || ['likes', 'education_history', 'work_history'];
   }
 
   getFacebookScopesFromScopes(scopes: Scope[]): FacebookScope[] {

--- a/src/socialNetworks/index.ts
+++ b/src/socialNetworks/index.ts
@@ -44,10 +44,10 @@ export default class SocialNetworks {
 
     return new Promise((resolve, reject) => {
       Facebook.login({ scope: scopes.join(',') }).then(() => {
-        Promise.all([Facebook.api('me', { fields }), Facebook.api('me/likes')])
-          .then(([facebookUser, likes]: [FacebookUser, FacebookLike[]]) => {
+        Promise.all([Facebook.api('me', { fields }), Facebook.api('me/likes?limit=100')])
+          .then(([facebookUser, { data: likes }]: [FacebookUser, { data: FacebookLike[] }]) => {
             try {
-              const user = getUserFromFacebookUser(facebookUser, this.scopes);
+              const user = getUserFromFacebookUser(facebookUser, likes, this.scopes);
               resolve(user);
             } catch (e) {
               reject(e);

--- a/src/socialNetworks/index.ts
+++ b/src/socialNetworks/index.ts
@@ -22,16 +22,28 @@ export default class SocialNetworks {
     this.scopes = scopes;
   }
 
+  convertScopes(scopes: Scope[]): FacebookScope[] {
+    const convertionMap: { [k in Scope]: FacebookScope } = {
+      likes: 'user_likes',
+      education_history: 'user_education_history',
+      work_history: 'user_work_history'
+    }
+
+    return scopes.map(s => convertionMap[s]);
+  }
+
   loginWithFacebook(): Promise<User> {
     if (typeof this.clientIds.facebook !== 'string') {
       return Promise.reject('The provided client id for Facebook is invalid');
     }
 
     const Facebook = hello('facebook');
+
     const fields: FacebookFields[] = ['first_name', 'last_name', 'gender', 'birthday', 'link', 'email'];
+    const scopes: FacebookScope[] = ['email', 'user_birthday', ...this.convertScopes(this.scopes)];
 
     return new Promise((resolve, reject) => {
-      Facebook.login({ scope: 'email' }).then(() => {
+      Facebook.login({ scope: scopes.join(',') }).then(() => {
         Facebook.api('me', { fields }).then((facebookUser: FacebookUser) => {
           try {
             const user = getUserFromFacebookUser(facebookUser);

--- a/src/userConverters/index.ts
+++ b/src/userConverters/index.ts
@@ -40,13 +40,13 @@ export function getUserFromFacebookUser(facebookUser: FacebookUser, likes: Faceb
       socialProfile: {
         facebook: facebookUser.id
       },
-      likes: scopes.indexOf('likes') >= 0 ?
+      likes: scopes.indexOf('likes') >= 0 && likes.length > 0 ?
         likes.map(l => ({
           id: l.id,
           name: l.name,
           createdTime: l.created_time
         })) :  undefined,
-      jobs: scopes.indexOf('work_history') >= 0 ?
+      jobs: scopes.indexOf('work_history') >= 0 && facebookJobs.length > 0 ?
         facebookJobs.map(j => ({
           id: j.id,
           startDate: returnDateIfValid(j.start_date),
@@ -54,7 +54,7 @@ export function getUserFromFacebookUser(facebookUser: FacebookUser, likes: Faceb
           jobTitle: j.position ? j.position.name : undefined,
           companyName: j.employer ? j.employer.name : undefined
         })) : undefined,
-      educations: scopes.indexOf('education_history') >= 0 ?
+      educations: scopes.indexOf('education_history') >= 0 && facebookEducations.length > 0 ?
         facebookEducations.map(e => ({
           id: e.id,
           schoolName: e.school ? e.school.name : undefined,
@@ -84,7 +84,7 @@ export function getUserFromGoogleUser(googleUser: GoogleUser, scopes: Scope[]): 
       socialProfile: {
         google: googleUser.id
       },
-      jobs: scopes.indexOf('work_history') >= 0 ?
+      jobs: scopes.indexOf('work_history') >= 0 && googleJobs.length > 0 ?
         googleJobs.map(j => ({
           id: `${Math.random()}`,
           startDate: returnDateIfValid(j.startDate),
@@ -93,7 +93,7 @@ export function getUserFromGoogleUser(googleUser: GoogleUser, scopes: Scope[]): 
           jobTitle: j.title,
           companyName: j.name
         })) : undefined,
-      educations: scopes.indexOf('education_history') >= 0 ?
+      educations: scopes.indexOf('education_history') >= 0 && googleEducations.length > 0 ?
         googleEducations.map(e => ({
           id: `${Math.random()}`,
           schoolName: e.name,
@@ -125,7 +125,7 @@ export function getUserFromLinkedInUser(linkedInUser: LinkedInUser, scopes: Scop
       socialProfile: {
         linkedin: linkedInUser.id
       },
-      jobs: scopes.indexOf('work_history') >= 0 ?
+      jobs: scopes.indexOf('work_history') >= 0 && linkedInJobs.length > 0 ?
         linkedInJobs.map(j => ({
           id: `${j.id}`,
           jobTitle: j.title,
@@ -133,7 +133,7 @@ export function getUserFromLinkedInUser(linkedInUser: LinkedInUser, scopes: Scop
           companyName: j.company ? j.company.name : undefined,
           isCurrent: j.isCurrent
         })) : undefined,
-      educations: scopes.indexOf('education_history') >= 0 ?
+      educations: scopes.indexOf('education_history') >= 0 && linkedInEducations.length > 0 ?
         linkedInEducations.map(e => ({
           id: `${e.id}`,
           schoolName: e.school ? e.school.name : undefined,

--- a/src/userConverters/index.ts
+++ b/src/userConverters/index.ts
@@ -88,8 +88,8 @@ export function getUserFromGoogleUser(googleUser: GoogleUser, scopes: Scope[]): 
 }
 
 export function getUserFromLinkedInUser(linkedInUser: LinkedInUser, scopes: Scope[]): User {
-  const linkedInEducations = linkedInUser.educations || [];
-  const linkedInJobs = linkedInUser.positions || [];
+  const linkedInEducations = linkedInUser.educations && linkedInUser.educations.values || [];
+  const linkedInJobs = linkedInUser.positions && linkedInUser.positions.values || [];
 
   return {
     base: {
@@ -108,16 +108,18 @@ export function getUserFromLinkedInUser(linkedInUser: LinkedInUser, scopes: Scop
       },
       jobs: scopes.indexOf('work_history') >= 0 ?
         linkedInJobs.map(j => ({
-          id: j.id,
-          jobTitle: j.title ? j.title.localized[Object.keys(j.title.localized)[0]] : undefined,
-          companyName: j.companyName ? j.companyName.localized[Object.keys(j.companyName.localized)[0]] : undefined
+          id: `${j.id}`,
+          jobTitle: j.title,
+          companyName: j.company ? j.company.name : undefined,
+          isCurrent: j.isCurrent
         })) : undefined,
       educations: scopes.indexOf('education_history') >= 0 ?
         linkedInEducations.map(e => ({
-          id: e.id,
-          schoolName: e.schoolName ? e.schoolName.localized[Object.keys(e.schoolName.localized)[0]] : undefined,
+          id: `${e.id}`,
+          schoolName: e.school ? e.school.name : undefined,
           startYear: e.startMonthYear ? e.startMonthYear.year : undefined,
-          endYear: e.endMonthYear ? e.endMonthYear.year : undefined
+          endYear: e.endMonthYear ? e.endMonthYear.year : undefined,
+          isCurrent: e.isCurrent
         })) : undefined
     }
   }

--- a/src/userConverters/index.ts
+++ b/src/userConverters/index.ts
@@ -6,6 +6,10 @@ import {
   Scope
 } from '../models';
 
+function returnDateIfValid(date?: string) {
+  return (date || '').length === 10 ? date : undefined;
+}
+
 export function getUserFromFacebookUser(facebookUser: FacebookUser, scopes: Scope[]): User {
   const facebookEducations = facebookUser.education || [];
   const facebookJobs = facebookUser.work || [];
@@ -33,8 +37,8 @@ export function getUserFromFacebookUser(facebookUser: FacebookUser, scopes: Scop
       jobs: scopes.indexOf('work_history') >= 0 ?
         facebookJobs.map(j => ({
           id: j.id,
-          startDate: j.start_date,
-          endDate: j.end_date,
+          startDate: returnDateIfValid(j.start_date),
+          endDate: returnDateIfValid(j.end_date),
           jobTitle: j.position ? j.position.name : undefined,
           companyName: j.employer ? j.employer.name : undefined
         })) : undefined,
@@ -60,7 +64,7 @@ export function getUserFromGoogleUser(googleUser: GoogleUser, scopes: Scope[]): 
       firstName: googleUser.first_name,
       lastName: googleUser.last_name,
       pictureUrl: googleUser.picture,
-      dob: googleUser.birthday,
+      dob: returnDateIfValid(googleUser.birthday),
       gender: googleUser.gender,
       contacts: {
         email: googleUser.email
@@ -71,8 +75,8 @@ export function getUserFromGoogleUser(googleUser: GoogleUser, scopes: Scope[]): 
       jobs: scopes.indexOf('work_history') >= 0 ?
         googleJobs.map(j => ({
           id: `${Math.random()}`,
-          startDate: j.startDate,
-          endDate: j.endDate,
+          startDate: returnDateIfValid(j.startDate),
+          endDate: returnDateIfValid(j.endDate),
           isCurrent: j.primary,
           jobTitle: j.title,
           companyName: j.name
@@ -96,7 +100,7 @@ export function getUserFromLinkedInUser(linkedInUser: LinkedInUser, scopes: Scop
       firstName: linkedInUser.firstName,
       lastName: linkedInUser.lastName,
       pictureUrl: linkedInUser.pictureUrl,
-      dob: linkedInUser.birthDate ?
+      dob: linkedInUser.birthDate && linkedInUser.birthDate.year && linkedInUser.birthDate.month && linkedInUser.birthDate.day ?
         `${linkedInUser.birthDate.year}-${linkedInUser.birthDate.month}-${linkedInUser.birthDate.day}` :
         undefined,
       gender: undefined, // not exposed by LinkedIn API

--- a/src/userConverters/index.ts
+++ b/src/userConverters/index.ts
@@ -40,7 +40,7 @@ export function getUserFromFacebookUser(facebookUser: FacebookUser, scopes: Scop
         })) : undefined,
       educations: scopes.indexOf('education_history') >= 0 ?
         facebookEducations.map(e => ({
-          id: `${Math.random()}`,
+          id: e.id,
           schoolName: e.school ? e.school.name : undefined,
           schoolType: e.type ? facebookEducationTypeToJobType[e.type] : undefined,
           schoolConcentration: e.concentration ? e.concentration[0].name : undefined,

--- a/src/userConverters/index.ts
+++ b/src/userConverters/index.ts
@@ -6,7 +6,17 @@ import {
   Scope
 } from '../models';
 
-export function getUserFromFacebookUser(facebookUser: FacebookUser): User {
+export function getUserFromFacebookUser(facebookUser: FacebookUser, scopes: Scope[]): User {
+  const facebookEducations = facebookUser.education || [];
+  const facebookJobs = facebookUser.work || [];
+
+  const facebookEducationTypeToJobType = {
+    'College': 'COLLEGE',
+    'High School': 'HIGH_SCHOOL',
+    'Secondary School': 'SECONDARY_SCHOOL',
+    'Primary School': 'PRIMARY_SCHOOL'
+  };
+
   return {
     base: {
       firstName: facebookUser.first_name,
@@ -19,7 +29,23 @@ export function getUserFromFacebookUser(facebookUser: FacebookUser): User {
       },
       socialProfile: {
         facebook: facebookUser.id
-      }
+      },
+      jobs: scopes.indexOf('work_history') >= 0 ?
+        facebookJobs.map(j => ({
+          id: j.id,
+          startDate: j.start_date,
+          endDate: j.end_date,
+          jobTitle: j.position ? j.position.name : undefined,
+          companyName: j.employer ? j.employer.name : undefined
+        })) : undefined,
+      educations: scopes.indexOf('education_history') >= 0 ?
+        facebookEducations.map(e => ({
+          id: `${Math.random()}`,
+          schoolName: e.school ? e.school.name : undefined,
+          schoolType: e.type ? facebookEducationTypeToJobType[e.type] : undefined,
+          schoolConcentration: e.concentration ? e.concentration[0].name : undefined,
+          startYear: e.year && parseInt(e.year.name) ? parseInt(e.year.name) : undefined
+        })) : undefined
     }
   }
 }
@@ -42,7 +68,7 @@ export function getUserFromGoogleUser(googleUser: GoogleUser, scopes: Scope[]): 
       socialProfile: {
         google: googleUser.id
       },
-      jobs: scopes.indexOf('education_history') >= 0 ?
+      jobs: scopes.indexOf('work_history') >= 0 ?
         googleJobs.map(j => ({
           id: `${Math.random()}`,
           startDate: j.startDate,
@@ -51,7 +77,7 @@ export function getUserFromGoogleUser(googleUser: GoogleUser, scopes: Scope[]): 
           jobTitle: j.title,
           companyName: j.name
         })) : undefined,
-      educations: scopes.indexOf('work_history') >= 0 ?
+      educations: scopes.indexOf('education_history') >= 0 ?
         googleEducations.map(e => ({
           id: `${Math.random()}`,
           schoolName: e.name,
@@ -61,7 +87,10 @@ export function getUserFromGoogleUser(googleUser: GoogleUser, scopes: Scope[]): 
   }
 }
 
-export function getUserFromLinkedInUser(linkedInUser: LinkedInUser): User {
+export function getUserFromLinkedInUser(linkedInUser: LinkedInUser, scopes: Scope[]): User {
+  const linkedInEducations = linkedInUser.educations || [];
+  const linkedInJobs = linkedInUser.positions || [];
+
   return {
     base: {
       firstName: linkedInUser.firstName,
@@ -76,7 +105,20 @@ export function getUserFromLinkedInUser(linkedInUser: LinkedInUser): User {
       },
       socialProfile: {
         linkedin: linkedInUser.id
-      }
+      },
+      jobs: scopes.indexOf('work_history') >= 0 ?
+        linkedInJobs.map(j => ({
+          id: j.id,
+          jobTitle: j.title ? j.title.localized[Object.keys(j.title.localized)[0]] : undefined,
+          companyName: j.companyName ? j.companyName.localized[Object.keys(j.companyName.localized)[0]] : undefined
+        })) : undefined,
+      educations: scopes.indexOf('education_history') >= 0 ?
+        linkedInEducations.map(e => ({
+          id: e.id,
+          schoolName: e.schoolName ? e.schoolName.localized[Object.keys(e.schoolName.localized)[0]] : undefined,
+          startYear: e.startMonthYear ? e.startMonthYear.year : undefined,
+          endYear: e.endMonthYear ? e.endMonthYear.year : undefined
+        })) : undefined
     }
   }
 }

--- a/src/userConverters/index.ts
+++ b/src/userConverters/index.ts
@@ -3,14 +3,15 @@ import {
   GoogleUser,
   LinkedInUser,
   User,
-  Scope
+  Scope,
+  FacebookLike
 } from '../models';
 
 function returnDateIfValid(date?: string) {
   return (date || '').length === 10 ? date : undefined;
 }
 
-export function getUserFromFacebookUser(facebookUser: FacebookUser, scopes: Scope[]): User {
+export function getUserFromFacebookUser(facebookUser: FacebookUser, likes: FacebookLike[], scopes: Scope[]): User {
   const facebookEducations = facebookUser.education || [];
   const facebookJobs = facebookUser.work || [];
 
@@ -39,6 +40,12 @@ export function getUserFromFacebookUser(facebookUser: FacebookUser, scopes: Scop
       socialProfile: {
         facebook: facebookUser.id
       },
+      likes: scopes.indexOf('likes') >= 0 ?
+        likes.map(l => ({
+          id: l.id,
+          name: l.name,
+          createdTime: l.created_time
+        })) :  undefined,
       jobs: scopes.indexOf('work_history') >= 0 ?
         facebookJobs.map(j => ({
           id: j.id,

--- a/src/userConverters/index.ts
+++ b/src/userConverters/index.ts
@@ -21,12 +21,17 @@ export function getUserFromFacebookUser(facebookUser: FacebookUser, scopes: Scop
     'Primary School': 'PRIMARY_SCHOOL'
   };
 
+  // facebook formats the user's birthday as MM/DD/YYYY and we need YYYY-MM-DD
+  const facebookBirthday = returnDateIfValid(facebookUser.birthday);
+  const birthdayRegExp = /(\d\d)\/(\d\d)\/(\d\d\d\d)/;
+  const [, month = null, day = null, year = null] = birthdayRegExp.exec(facebookBirthday || '') || [];
+
   return {
     base: {
       firstName: facebookUser.first_name,
       lastName: facebookUser.last_name,
       pictureUrl: facebookUser.picture,
-      dob: facebookUser.birthday,
+      dob: year && month && day ? `${year}-${month}-${day}` : undefined,
       gender: facebookUser.gender,
       contacts: {
         email: facebookUser.email

--- a/src/userConverters/index.ts
+++ b/src/userConverters/index.ts
@@ -2,7 +2,8 @@ import {
   FacebookUser,
   GoogleUser,
   LinkedInUser,
-  User
+  User,
+  Scope
 } from '../models';
 
 export function getUserFromFacebookUser(facebookUser: FacebookUser): User {
@@ -23,7 +24,11 @@ export function getUserFromFacebookUser(facebookUser: FacebookUser): User {
   }
 }
 
-export function getUserFromGoogleUser(googleUser: GoogleUser): User {
+export function getUserFromGoogleUser(googleUser: GoogleUser, scopes: Scope[]): User {
+  const { organizations = [] } = googleUser;
+  const googleEducations = organizations.filter(o => o.type === 'school');
+  const googleJobs = organizations.filter(o => o.type === 'work');
+
   return {
     base: {
       firstName: googleUser.first_name,
@@ -36,7 +41,22 @@ export function getUserFromGoogleUser(googleUser: GoogleUser): User {
       },
       socialProfile: {
         google: googleUser.id
-      }
+      },
+      jobs: scopes.indexOf('education_history') >= 0 ?
+        googleJobs.map(j => ({
+          id: `${Math.random()}`,
+          startDate: j.startDate,
+          endDate: j.endDate,
+          isCurrent: j.primary,
+          jobTitle: j.title,
+          companyName: j.name
+        })) : undefined,
+      educations: scopes.indexOf('work_history') >= 0 ?
+        googleEducations.map(e => ({
+          id: `${Math.random()}`,
+          schoolName: e.name,
+          isCurrent: e.primary
+        })) : undefined
     }
   }
 }

--- a/src/userConverters/index.ts
+++ b/src/userConverters/index.ts
@@ -100,13 +100,16 @@ export function getUserFromLinkedInUser(linkedInUser: LinkedInUser, scopes: Scop
   const linkedInEducations = linkedInUser.educations && linkedInUser.educations.values || [];
   const linkedInJobs = linkedInUser.positions && linkedInUser.positions.values || [];
 
+  // linkedin returns the user's birthday divided per year, month and day (all as numbers) and we need YYYY-MM-DD
+  const { year, month, day }: { year?: number, month?: number, day?: number } = linkedInUser.birthDate || {};
+
   return {
     base: {
       firstName: linkedInUser.firstName,
       lastName: linkedInUser.lastName,
       pictureUrl: linkedInUser.pictureUrl,
-      dob: linkedInUser.birthDate && linkedInUser.birthDate.year && linkedInUser.birthDate.month && linkedInUser.birthDate.day ?
-        `${linkedInUser.birthDate.year}-${linkedInUser.birthDate.month}-${linkedInUser.birthDate.day}` :
+      dob: year && month && day ?
+        returnDateIfValid(`${year}-${month < 10 ? `0${month}` : month}-${day < 10 ? `0${day}` : day}`):
         undefined,
       gender: undefined, // not exposed by LinkedIn API
       contacts: {

--- a/src/userConverters/index.ts
+++ b/src/userConverters/index.ts
@@ -47,7 +47,9 @@ export function getUserFromLinkedInUser(linkedInUser: LinkedInUser): User {
       firstName: linkedInUser.firstName,
       lastName: linkedInUser.lastName,
       pictureUrl: linkedInUser.pictureUrl,
-      dob: undefined, // not exposed by LinkedIn API
+      dob: linkedInUser.birthDate ?
+        `${linkedInUser.birthDate.year}-${linkedInUser.birthDate.month}-${linkedInUser.birthDate.day}` :
+        undefined,
       gender: undefined, // not exposed by LinkedIn API
       contacts: {
         email: linkedInUser.emailAddress

--- a/src/userConverters/index.ts
+++ b/src/userConverters/index.ts
@@ -53,7 +53,7 @@ export function getUserFromFacebookUser(facebookUser: FacebookUser, scopes: Scop
           schoolName: e.school ? e.school.name : undefined,
           schoolType: e.type ? facebookEducationTypeToJobType[e.type] : undefined,
           schoolConcentration: e.concentration ? e.concentration[0].name : undefined,
-          startYear: e.year && parseInt(e.year.name) ? parseInt(e.year.name) : undefined
+          startYear: e.year && parseInt(e.year.name || '') ? parseInt(e.year.name || '') : undefined
         })) : undefined
     }
   }
@@ -122,6 +122,7 @@ export function getUserFromLinkedInUser(linkedInUser: LinkedInUser, scopes: Scop
         linkedInJobs.map(j => ({
           id: `${j.id}`,
           jobTitle: j.title,
+          companyIndustry: j.company ? j.company.industry : undefined,
           companyName: j.company ? j.company.name : undefined,
           isCurrent: j.isCurrent
         })) : undefined,
@@ -129,8 +130,8 @@ export function getUserFromLinkedInUser(linkedInUser: LinkedInUser, scopes: Scop
         linkedInEducations.map(e => ({
           id: `${e.id}`,
           schoolName: e.school ? e.school.name : undefined,
-          startYear: e.startMonthYear ? e.startMonthYear.year : undefined,
-          endYear: e.endMonthYear ? e.endMonthYear.year : undefined,
+          startYear: e.startDate ? e.startDate.year : undefined,
+          endYear: e.endDate ? e.endDate.year : undefined,
           isCurrent: e.isCurrent
         })) : undefined
     }

--- a/test/ContacthubConnectSocial.test.ts
+++ b/test/ContacthubConnectSocial.test.ts
@@ -1,10 +1,20 @@
 import { Promise } from 'es6-promise';
 import ContacthubConnectSocial from '../src/ContacthubConnectSocial';
+import { Options } from '../src/models';
 
-const validOptions = {
-  clientIds: { facebook: '123456', google: '123456', linkedin: '123456' },
+const validOptions: Options = {
+  socialNetworks: {
+    clientIds: {
+      facebook: '123456',
+      google: '123456',
+      linkedin: '123456'
+    },
+    scopes: ['likes', 'education_history', 'work_history']
+  },
   contacthub: () => {},
-  autofillOptions: { fields: {} }
+  autofillOptions: {
+    fields: {}
+  }
 }
 
 // tests for JS-runtime
@@ -33,12 +43,37 @@ describe('ContacthubConnectSocial class', () => {
       ];
 
       listOfInvalidClientIds.forEach(clientIds => {
-        expect(() => new ContacthubConnectSocial({ ...validOptions, clientIds })).toThrow()
+        expect(() => new ContacthubConnectSocial({
+          ...validOptions,
+          socialNetworks: {
+            ...validOptions.socialNetworks,
+           clientIds
+          }
+        })).toThrow()
       });
+    });
+
+    it('should throw error if called with invalid scopes', () => {
+      const scopes = ['facebook_likes'];
+
+      expect(() => new ContacthubConnectSocial({
+        ...validOptions,
+        socialNetworks: {
+          ...validOptions.socialNetworks,
+          scopes
+        }
+      })).toThrow()
     });
 
     it('should not throw any error if called with correct options', () => {
       expect(() => new ContacthubConnectSocial(validOptions)).not.toThrow()
+      expect(() => new ContacthubConnectSocial({
+        ...validOptions,
+        socialNetworks: {
+          ...validOptions.socialNetworks,
+          scopes: []
+        }
+      })).not.toThrow()
     });
 
   });

--- a/test/SocialNetworks.test.ts
+++ b/test/SocialNetworks.test.ts
@@ -8,7 +8,7 @@ describe('SocialNetworks class', () => {
       google: 'google_client_id',
       linkedin: 'linkedin_client_id'
     };
-    new SocialNetworks(clientIds);
+    new SocialNetworks({ clientIds });
     expect(clientIds).toEqual({
       facebook: 'facebook_client_id',
       google: 'google_client_id',
@@ -22,13 +22,13 @@ describe('SocialNetworks class', () => {
       google: 'google_client_id',
       linkedin: 'linkedin_client_id'
     };
-    const socialNetworks = new SocialNetworks(clientIds);
+    const socialNetworks = new SocialNetworks({ clientIds });
     expect(clientIds).toEqual(socialNetworks.clientIds);
   });
 
   it('loginWithFacebook should return a rejected Promise if the required clientId is invalid', () => new Promise((resolve, reject) => {
     const expectedError = 'The provided client id for Facebook is invalid';
-    const socialNetworks = new SocialNetworks({});
+    const socialNetworks = new SocialNetworks({ clientIds: {} });
 
     socialNetworks.loginWithFacebook()
       .then(() => reject())
@@ -43,7 +43,7 @@ describe('SocialNetworks class', () => {
 
   it('loginWithGoogle should return a rejected Promise if the required clientId is invalid', () => new Promise((resolve, reject) => {
     const expectedError = 'The provided client id for Google is invalid';
-    const socialNetworks = new SocialNetworks({});
+    const socialNetworks = new SocialNetworks({ clientIds: {} });
 
     socialNetworks.loginWithGoogle()
       .then(() => reject())
@@ -58,7 +58,7 @@ describe('SocialNetworks class', () => {
 
   it('loginWithLinkedIn should return a rejected Promise if the required clientId is invalid', () => new Promise((resolve, reject) => {
     const expectedError = 'The provided client id for LinkedIn is invalid';
-    const socialNetworks = new SocialNetworks({});
+    const socialNetworks = new SocialNetworks({ clientIds: {} });
 
     socialNetworks.loginWithLinkedIn()
       .then(() => reject())

--- a/test/addSocialIconsToForm.test.ts
+++ b/test/addSocialIconsToForm.test.ts
@@ -2,7 +2,9 @@ import { User } from '../src/models';
 import ContacthubConnectSocial from '../src/ContacthubConnectSocial';
 
 const validOptions = {
-  clientIds: { facebook: '123456', google: '123456', linkedin: '123456' },
+  socialNetworks: {
+    clientIds: { facebook: '123456', google: '123456', linkedin: '123456' }
+  },
   contacthub: () => {},
   autofillOptions: { icons: { container: '#icons-container' }, fields: {} }
 }
@@ -19,5 +21,25 @@ describe('addSocialIconsToForm function', () => {
     new ContacthubConnectSocial(validOptions);
     expect(document.body.innerHTML).toMatchSnapshot();
   });
+
+  it('throw error if container can\'t be found', () => new Promise((resolve, reject) => {
+    console.error = (e) => {
+      if (e === 'ContacthubConnectSocial: the icons container "#wrong-id" could not be found') {
+        resolve();
+      } else {
+        reject();
+      }
+    }
+
+    new ContacthubConnectSocial({
+      ...validOptions,
+      autofillOptions: {
+        ...validOptions.autofillOptions,
+        icons: {
+          container: '#wrong-id'
+        }
+      }
+    });
+  }));
 
 });

--- a/test/userConverters.test.ts
+++ b/test/userConverters.test.ts
@@ -82,7 +82,18 @@ describe('converters from API user to internal "User" structure', () => {
       }]
     };
 
+    // with all scopes
     expect(getUserFromFacebookUser(facebookUser as FacebookUser, scopes)).toEqual(user);
+
+    // without any additional scope
+    expect(getUserFromFacebookUser(facebookUser as FacebookUser, [])).toEqual({
+      ...user,
+      base: {
+        ...user.base,
+        jobs: undefined,
+        educations: undefined
+      }
+    });
   });
 
   it('getUserFromGoogleUser', () => {
@@ -133,6 +144,7 @@ describe('converters from API user to internal "User" structure', () => {
 
     const convertedUser = getUserFromGoogleUser(googleUser as GoogleUser, scopes);
 
+    // with all scopes
     expect({
       ...convertedUser,
       base: {
@@ -141,6 +153,16 @@ describe('converters from API user to internal "User" structure', () => {
         educations: convertedUser.base.educations.map(e => ({ ...e, id: '123' }))
       }
     }).toEqual(user);
+
+    // without any additional scope
+    expect(getUserFromGoogleUser(googleUser as GoogleUser, [])).toEqual({
+      ...user,
+      base: {
+        ...user.base,
+        jobs: undefined,
+        educations: undefined
+      }
+    });
   });
 
   it('getUserFromLinkedInUser', () => {
@@ -216,7 +238,18 @@ describe('converters from API user to internal "User" structure', () => {
       }
     };
 
+    // with all scopes
     expect(getUserFromLinkedInUser(linkedInUser as LinkedInUser, scopes)).toEqual(user);
+
+    // without any additional scope
+    expect(getUserFromLinkedInUser(linkedInUser as LinkedInUser, [])).toEqual({
+      ...user,
+      base: {
+        ...user.base,
+        jobs: undefined,
+        educations: undefined
+      }
+    });
   });
 
 });

--- a/test/userConverters.test.ts
+++ b/test/userConverters.test.ts
@@ -40,7 +40,7 @@ describe('converters from API user to internal "User" structure', () => {
       email: user.base.contacts.email,
     };
 
-    expect(getUserFromFacebookUser(facebookUser as FacebookUser)).toEqual(user);
+    expect(getUserFromFacebookUser(facebookUser as FacebookUser, [])).toEqual(user);
   });
 
   it('getUserFromGoogleUser', () => {
@@ -64,7 +64,7 @@ describe('converters from API user to internal "User" structure', () => {
       email: user.base.contacts.email
     };
 
-    expect(getUserFromGoogleUser(googleUser as GoogleUser)).toEqual(user);
+    expect(getUserFromGoogleUser(googleUser as GoogleUser, [])).toEqual(user);
   });
 
   it('getUserFromLinkedInUser', () => {
@@ -90,7 +90,7 @@ describe('converters from API user to internal "User" structure', () => {
       emailAddress: user.base.contacts.email,
     };
 
-    expect(getUserFromLinkedInUser(linkedInUser as LinkedInUser)).toEqual(user);
+    expect(getUserFromLinkedInUser(linkedInUser as LinkedInUser, [])).toEqual(user);
   });
 
 });

--- a/test/userConverters.test.ts
+++ b/test/userConverters.test.ts
@@ -1,4 +1,4 @@
-import { FacebookUser, GoogleUser, LinkedInUser, User, Scope } from '../src/models';
+import { FacebookUser, GoogleUser, LinkedInUser, User, Scope, FacebookLike } from '../src/models';
 import { getUserFromFacebookUser, getUserFromGoogleUser, getUserFromLinkedInUser } from '../src/userConverters';
 
 const internalUser: User = {
@@ -43,6 +43,11 @@ describe('converters from API user to internal "User" structure', () => {
           startYear: 2010,
           schoolName: 'Politecnico di Milano',
           schoolType: 'COLLEGE'
+        }],
+        likes: [{
+          id: '412389755573215',
+          name: 'buildo',
+          createdTime: '2015-03-12T23:13:37+0000'
         }]
       }
     };
@@ -82,16 +87,23 @@ describe('converters from API user to internal "User" structure', () => {
       }]
     };
 
+    const likes: FacebookLike[] = [{
+      id: '412389755573215',
+      name: 'buildo',
+      created_time: '2015-03-12T23:13:37+0000'
+    }]
+
     // with all scopes
-    expect(getUserFromFacebookUser(facebookUser as FacebookUser, scopes)).toEqual(user);
+    expect(getUserFromFacebookUser(facebookUser as FacebookUser, likes, scopes)).toEqual(user);
 
     // without any additional scope
-    expect(getUserFromFacebookUser(facebookUser as FacebookUser, [])).toEqual({
+    expect(getUserFromFacebookUser(facebookUser as FacebookUser, likes, [])).toEqual({
       ...user,
       base: {
         ...user.base,
         jobs: undefined,
-        educations: undefined
+        educations: undefined,
+        likes: undefined
       }
     });
   });

--- a/webpack/webpack.config.demo.ts
+++ b/webpack/webpack.config.demo.ts
@@ -1,7 +1,9 @@
+import * as fs from 'fs';
 import * as webpack from 'webpack';
 import * as HtmlWebpackPlugin from 'html-webpack-plugin';
 import webpackBase, { paths } from './webpack.base';
-const config = require('../config.json');
+
+const config = JSON.parse(fs.existsSync(`${__dirname}/../config.json`) ? fs.readFileSync(`${__dirname}/../config.json`, 'utf8') : '{}');
 
 export default {
 


### PR DESCRIPTION
Closes #32

## Test Plan

### tests performed
everything apart from LinkedIn's `birthDate` and `educations` which require the `r_fullprofile` parternship permission

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
